### PR TITLE
call out explicitly the IANA registry

### DIFF
--- a/draft-ietf-alto-new-transport.md
+++ b/draft-ietf-alto-new-transport.md
@@ -87,6 +87,10 @@ normative:
 
 informative:
   RFC9205:
+  IANA-Media-Type:
+    title: Media Types
+    target: [https://www.iana.org/assignments/ipfix/ipfix.xhtml](https://www.iana.org/assignments/media-types/media-types.xhtml)
+    date: 2023-06
 
 --- abstract
 
@@ -1874,8 +1878,7 @@ and responses (Section 15 of {{RFC7285}}).
 
 # IANA Considerations
 
-IANA is requested to register the following media types following the
-same process in {{RFC7285}}:
+IANA is requested to register the following media types from the registry available at {{IANA-Media-Type}}:
 
 *  application/alto-tips+json: as described in {{open-resp}};
 


### PR DESCRIPTION
This will help me fix this part in the writeup: 

20. Describe the document shepherd's review of the IANA considerations section, especially with regard to its consistency with the body of the document. Confirm that all aspects of the document requiring IANA assignments are associated with the appropriate reservations in IANA registries. Confirm that any referenced IANA registries have been clearly identified. Confirm that each newly created IANA registry specifies its initial contents, allocations procedures, and a reasonable name (see [RFC 8126][11]).